### PR TITLE
refactor event/event_body

### DIFF
--- a/src/event.rs
+++ b/src/event.rs
@@ -1,0 +1,39 @@
+use std::cmp::Ordering;
+
+#[derive(PartialEq, Eq, Debug)]
+pub enum Event {
+    Update(String),
+    Evaluate(i32),
+    End,
+    Test(i32),
+}
+
+#[derive(Eq, Debug)]
+pub struct EventWrapper {
+    pub time: u32,
+    pub event: Event
+}
+
+impl Ord for EventWrapper {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.time.cmp(&other.time).reverse()
+    }
+}
+
+impl PartialOrd for EventWrapper {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl PartialEq for EventWrapper {
+    fn eq(&self, other: &Self) -> bool {
+        self.time == other.time
+    }
+}
+
+impl EventWrapper {
+    pub fn new(time: u32, event: Event) -> Self {
+        Self {time, event}
+    }
+}

--- a/src/event_queue.rs
+++ b/src/event_queue.rs
@@ -1,52 +1,15 @@
 use std::{
-    cmp::{Ordering},
     collections::BinaryHeap,
     vec::Vec,
 };
 
-#[derive(PartialEq, Eq, Debug)]
-pub enum EventBody {
-    Update(String),
-    Evaluate(i32),
-    End,
-    Test(i32),
-}
-
-#[derive(Eq, Debug)]
-pub struct Event {
-    time: u32,
-    pub body: EventBody
-}
-
-impl Ord for Event {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.time.cmp(&other.time).reverse()
-    }
-}
-
-impl PartialOrd for Event {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl PartialEq for Event {
-    fn eq(&self, other: &Self) -> bool {
-        self.time == other.time
-    }
-}
-
-impl Event {
-    pub fn new(time: u32, body: EventBody) -> Self {
-        Self {time, body}
-    }
-}
+use crate::event::*;
 
 #[derive(Default)]
 pub struct EventQueue {
     active: Vec<Event>,
     inactive: Vec<Event>,
-    future: BinaryHeap<Event>
+    future: BinaryHeap<EventWrapper>
 }
 
 impl EventQueue {
@@ -70,13 +33,10 @@ impl EventQueue {
             let time = event.time;
             while !self.future.is_empty() {
                 if self.future.peek().unwrap().time > time { break; }
-                self.active.push(self.future.pop().unwrap())
+                self.active.push(self.future.pop().unwrap().event)
             }
         } else {
-            self.active.push(Event {
-                time: 0,
-                body: EventBody::End
-            });
+            self.active.push(Event::End);
         }
     }
 }
@@ -86,43 +46,43 @@ mod tests {
     use super::*;
 
     fn event_has_testid(event: &Event, id: i32) -> bool {
-        match event.body {
-            EventBody::Test(tid) => tid == id,
+        match event {
+            Event::Test(tid) => *tid == id,
             _ => false
         }
     }
 
     fn vector_has_event_testid(collection: &Vec<Event>, id:i32) -> bool {
-        collection.iter().any(|event| match event.body {
-            EventBody::Test(tid) => tid == id,
+        collection.iter().any(|event| match event {
+            Event::Test(tid) => *tid == id,
             _ => false
         })
     }
 
-    fn heap_has_event_testid(collection: &BinaryHeap<Event>, id:i32) -> bool {
-        collection.iter().any(|event| match event.body {
-            EventBody::Test(tid) => tid == id,
+    fn heap_has_event_wrapper_testid(collection: &BinaryHeap<EventWrapper>, id:i32) -> bool {
+        collection.iter().any(|event_wrapper| match event_wrapper.event {
+            Event::Test(tid) => tid == id,
             _ => false
         })
     }
 
     fn vector_has_event_end(collection: &Vec<Event>) -> bool {
-        collection.iter().any(|event| match event.body {
-            EventBody::End => true,
+        collection.iter().any(|event| match event {
+            Event::End => true,
             _ => false
         })
     }
 
     fn event_is_end(event: &Event) -> bool {
-        match event.body {
-            EventBody::End => true,
+        match event {
+            Event::End => true,
             _ => false
         }
     }
 
     fn event_has_testid_in(event: &Event, ids: Vec<i32>) -> bool {
-        match event.body {
-            EventBody::Test(id) => ids.contains(&id),
+        match event {
+            Event::Test(id) => ids.contains(&id),
             _ => false
         }
     }
@@ -130,9 +90,9 @@ mod tests {
     #[test]
     fn advance_time_test_progress() {
         let mut queue: EventQueue = Default::default();
-        queue.future.push(Event::new(1, EventBody::Test(1)));
-        queue.future.push(Event::new(1, EventBody::Test(2)));
-        queue.future.push(Event::new(2, EventBody::Test(3)));
+        queue.future.push(EventWrapper::new(1, Event::Test(1)));
+        queue.future.push(EventWrapper::new(1, Event::Test(2)));
+        queue.future.push(EventWrapper::new(2, Event::Test(3)));
 
         queue.advance_time();
 
@@ -142,7 +102,7 @@ mod tests {
 
         assert!(vector_has_event_testid(&queue.active, 1), "active contins event 1");
         assert!(vector_has_event_testid(&queue.active, 2), "active contins event 2");
-        assert!(heap_has_event_testid(&queue.future, 3), "future contins event 3");
+        assert!(heap_has_event_wrapper_testid(&queue.future, 3), "future contins event 3");
     }
 
     #[test]
@@ -158,9 +118,9 @@ mod tests {
     fn activate_inactive_events_test() {
         let mut queue: EventQueue = Default::default();
         
-        queue.inactive.push(Event::new(1, EventBody::Test(1)));
-        queue.inactive.push(Event::new(1, EventBody::Test(2)));
-        queue.future.push(Event::new(2, EventBody::Test(3)));
+        queue.inactive.push(Event::Test(1));
+        queue.inactive.push(Event::Test(2));
+        queue.future.push(EventWrapper::new(2, Event::Test(3)));
 
         queue.activate_inactive_events();
 
@@ -170,16 +130,16 @@ mod tests {
 
         assert!(vector_has_event_testid(&queue.active, 1), "active contins event 1");
         assert!(vector_has_event_testid(&queue.active, 2), "active contins event 2");
-        assert!(heap_has_event_testid(&queue.future, 3), "future contins event 3");
+        assert!(heap_has_event_wrapper_testid(&queue.future, 3), "future contins event 3");
     }
     
     #[test]
     fn activate_inactive_events_test_advance_time() {
         let mut queue: EventQueue = Default::default();
         
-        queue.future.push(Event::new(1, EventBody::Test(1)));
-        queue.future.push(Event::new(1, EventBody::Test(2)));
-        queue.future.push(Event::new(2, EventBody::Test(3)));
+        queue.future.push(EventWrapper::new(1, Event::Test(1)));
+        queue.future.push(EventWrapper::new(1, Event::Test(2)));
+        queue.future.push(EventWrapper::new(2, Event::Test(3)));
 
         queue.activate_inactive_events();
 
@@ -189,7 +149,7 @@ mod tests {
 
         assert!(vector_has_event_testid(&queue.active, 1), "active contins event 1");
         assert!(vector_has_event_testid(&queue.active, 2), "active contins event 2");
-        assert!(heap_has_event_testid(&queue.future, 3), "future contins event 3");
+        assert!(heap_has_event_wrapper_testid(&queue.future, 3), "future contins event 3");
     }
     
     #[test]
@@ -209,9 +169,9 @@ mod tests {
     fn next_event_test() {
         let mut queue: EventQueue = Default::default();
         
-        queue.active.push(Event::new(1, EventBody::Test(1)));
-        queue.active.push(Event::new(1, EventBody::Test(2)));
-        queue.active.push(Event::new(1, EventBody::Test(3)));
+        queue.active.push(Event::Test(1));
+        queue.active.push(Event::Test(2));
+        queue.active.push(Event::Test(3));
 
         let event = queue.next_event();
 
@@ -222,9 +182,9 @@ mod tests {
     fn next_event_test_activate_inactive() {
         let mut queue: EventQueue = Default::default();
         
-        queue.inactive.push(Event::new(1, EventBody::Test(1)));
-        queue.inactive.push(Event::new(1, EventBody::Test(2)));
-        queue.inactive.push(Event::new(1, EventBody::Test(3)));
+        queue.inactive.push(Event::Test(1));
+        queue.inactive.push(Event::Test(2));
+        queue.inactive.push(Event::Test(3));
 
         let event = queue.next_event();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,17 @@
+mod event;
 mod event_queue;
 
-use event_queue::*;
+
+use event_queue::EventQueue;
+use event::Event;
 
 fn main() {
     let mut queue: EventQueue = Default::default();
 
     //main simulation loop
     loop {
-        match queue.next_event().body {
-            EventBody::End => break,
+        match queue.next_event() {
+            Event::End => break,
             _ => ()
         }
     }


### PR DESCRIPTION
changed event body to event
change event to event wrapper

queue.active and .inactive are collections of events (all assoc. w/ current time)

queue.future is a collection of eventWrappers

event(wrapper) in its own file